### PR TITLE
Make Project Settings accesible from anywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,10 +158,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
@@ -184,12 +216,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
 name = "gi"
 version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
+ "dialoguer",
  "eyre",
+ "once_cell",
  "serde",
  "serde_json",
  "which",
@@ -227,6 +267,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -351,6 +397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,10 +420,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "utf8parse"
@@ -469,3 +559,9 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 color-eyre = {version = "0.6.3", default-features = false}
+dialoguer = "0.11.0"
 eyre = "0.6.12"
+once_cell = "1.19.0"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 which = "6.0.1"

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -1,7 +1,14 @@
 use eyre::{Ok, Result};
 
-use crate::{git_client::GitClient, project::settings::ProjectSettings};
+use crate::{project::settings::PROJECT_SETTINGS, IssueError};
 
-pub fn create(git_client: &impl GitClient, project_settings: &mut ProjectSettings) -> Result<()> {
+pub fn create() -> Result<()> {
+    let trunk = PROJECT_SETTINGS
+        .lock()
+        .to_issue_error("Failed to get project settings mutex")?
+        .get_trunk()?;
+
+    println!("Trunk: {}", trunk);
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,20 @@
+use color_eyre::Section;
+use eyre::Result;
+use std::sync::LockResult;
+
 pub mod cli;
 pub mod commands;
 pub mod git_client;
 pub mod project;
+
+pub trait IssueError<T> {
+    fn to_issue_error(self, error: &str) -> Result<T>;
+}
+
+impl<T> IssueError<T> for LockResult<T> {
+    fn to_issue_error(self, error: &str) -> Result<T> {
+        self.map_err(|_| {
+            eyre::eyre!(error.to_owned()).suggestion("This is most likely a bug, please report it at https://github.com/costinsin/gi/issues")
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,15 @@ use eyre::Result;
 use gi::{
     cli::args::{Args, Commands},
     commands::create::create,
-    project::settings::ProjectSettings,
 };
 
 fn main() -> Result<()> {
     let args = Args::parse();
 
     color_eyre::install()?;
-    let git_client = gi::git_client::git_cli::GitCli::new()?;
-    let mut project_settings = ProjectSettings::new()?;
 
     match args.command {
-        Commands::Create => create(&git_client, &mut project_settings)?,
+        Commands::Create => create()?,
     }
 
     Ok(())

--- a/src/project/settings.rs
+++ b/src/project/settings.rs
@@ -1,16 +1,20 @@
-use std::path::Path;
-
 use color_eyre::Section;
+use dialoguer::theme::ColorfulTheme;
 use eyre::{eyre, Ok, Result};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::{path::Path, sync::Mutex};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ProjectSettings {
-    pub trunk: Option<String>,
+    trunk: Option<String>,
 }
 
+pub static PROJECT_SETTINGS: Lazy<Mutex<ProjectSettings>> =
+    Lazy::new(|| Mutex::new(ProjectSettings::load().unwrap()));
+
 impl ProjectSettings {
-    pub fn new() -> Result<Self> {
+    fn load() -> Result<Self> {
         if !Path::new(".git").exists() {
             return Err(eyre!("You are not inside a git repository.").suggestion(
                 "Run `gt` inside a git repository or run `git init` to create a new one.",
@@ -38,12 +42,25 @@ impl ProjectSettings {
         Ok(settings?)
     }
 
-    pub fn set_trunk(&mut self, trunk: String) -> &mut Self {
-        self.trunk = Some(trunk);
-        self
+    pub fn set_trunk(&mut self, trunk: &String) -> Result<()> {
+        self.trunk = Some(trunk.clone());
+        self.save()?;
+
+        Ok(())
     }
 
-    pub fn save(&self) -> Result<()> {
+    pub fn get_trunk(&mut self) -> Result<String> {
+        let trunk = match self.trunk.to_owned() {
+            Some(a) => a,
+            None => ask_for_trunk()?,
+        };
+
+        self.set_trunk(&trunk)?;
+
+        Ok(trunk)
+    }
+
+    fn save(&self) -> Result<()> {
         let content = serde_json::to_string(self)?;
         std::fs::write(".git/.gi_project_config", content).map_err(|_| {
             eyre!("Failed to save project settings")
@@ -52,4 +69,13 @@ impl ProjectSettings {
 
         Ok(())
     }
+}
+
+pub fn ask_for_trunk() -> Result<String> {
+    let trunk = dialoguer::Input::<String>::with_theme(&ColorfulTheme::default())
+        .with_prompt("What is the name of the trunk branch?")
+        .default("main".to_string())
+        .interact()?;
+
+    Ok(trunk)
 }


### PR DESCRIPTION
I have converted the Project Settings to a static global variable
which is placed behind a Mutex to account for concurrent accesses.

I don't think our CLI will use concurent accesses, but this is
the right way to do it, Rust won't let us do this in other ways.