### PR TITLE
Regex and provider enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,8 +463,11 @@ dependencies = [
  "eyre",
  "octocrab",
  "once_cell",
+ "regex",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tokio",
  "which",
 ]
@@ -959,6 +971,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1086,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -1236,6 +1283,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ dialoguer = "0.11.0"
 eyre = "0.6.12"
 octocrab = "0.38.0"
 once_cell = "1.19.0"
+regex = "1.10.4"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
+strum = "0.26.2"
+strum_macros = "0.26.2"
 tokio = { version = "1.37.0", features = ["full"] }
 which = "6.0.1"

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,22 +1,19 @@
-use color_eyre::Section;
 use eyre::{Ok, Result};
 
 use crate::{
-    git_client::{self},
-    git_provider::{self, GitProvider},
+    git_client,
+    git_provider::{provider_factory, GitProvider},
     project::settings::get_project_settings,
 };
 
 pub async fn submit() -> Result<()> {
-    let (provider, _owner, _repo) = git_client::get_git_client()?.get_repo_info()?;
-
-    let provider_obj = match provider.as_str() {
-        "github" => git_provider::github::GitHub::new()?,
-        _ => Err(eyre::eyre!("Unsupported provider")).suggestion("Supported providers: GitHub")?,
-    };
-
+    let (provider, owner, repo) = git_client::get_git_client()?.get_repo_info()?;
+    let provider_obj = provider_factory(&provider)?;
     let trunk = get_project_settings()?.get_trunk()?;
-    provider_obj.create_pull_request(trunk).await?;
+
+    provider_obj
+        .create_pull_request(&owner, &repo, &trunk)
+        .await?;
 
     Ok(())
 }

--- a/src/git_client/mod.rs
+++ b/src/git_client/mod.rs
@@ -1,4 +1,5 @@
 use crate::IssueError;
+use crate::git_provider::SupportedProviders;
 
 use self::git_cli::GitCli;
 use eyre::Result;
@@ -10,7 +11,7 @@ pub mod git_cli;
 pub trait GitClient: Send + Sync {
     fn interactive_commit(&self);
     fn checkout(&self, branch: &str);
-    fn get_repo_info(&self) -> Result<(String, String, String)>;
+    fn get_repo_info(&self) -> Result<(SupportedProviders, String, String)>;
 }
 
 static GIT_CLIENT: Lazy<Mutex<Box<dyn GitClient>>> =

--- a/src/git_provider/github.rs
+++ b/src/git_provider/github.rs
@@ -12,14 +12,21 @@ impl GitHub {
 }
 
 impl GitProvider for GitHub {
-    async fn create_pull_request(&self, trunk: String) -> Result<()> {
+    async fn create_pull_request(
+        &self,
+        owner: &String,
+        repo: &String,
+        trunk: &String,
+    ) -> Result<()> {
+        println!("Creating pull request");
+
         let octocrab = octocrab::Octocrab::builder()
             .build()
             .context("Failed to create octocrab instance")
             .suggestion("Please check your GitHub credentials")?;
 
         let _pr = octocrab
-            .pulls("owner", "repo")
+            .pulls(owner, repo)
             .create("title", "head", trunk)
             .body("hello world!")
             .send()

--- a/src/git_provider/mod.rs
+++ b/src/git_provider/mod.rs
@@ -1,7 +1,61 @@
 #![allow(async_fn_in_trait)]
 
+use core::fmt;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+use color_eyre::Section;
+use eyre::Result;
+
 pub mod github;
 
+#[derive(EnumIter)]
+pub enum SupportedProviders {
+    GitHub,
+}
+
+impl fmt::Display for SupportedProviders {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SupportedProviders::GitHub => write!(f, "GitHub"),
+        }
+    }
+}
+
+impl SupportedProviders {
+    pub fn get_providers() -> String {
+        let mut s = String::new();
+
+        for provider in SupportedProviders::iter() {
+            s.push_str(&format!("{}, ", provider));
+        }
+
+        s[..s.len() - 2].to_string()
+    }
+}
+
+pub fn get_provider_enum(provider: &str) -> Result<SupportedProviders> {
+    match provider {
+        "github" => Ok(SupportedProviders::GitHub),
+        p => Err(eyre::eyre!("Unsupported provider {}", p)).suggestion(format!(
+            "Supported providers: {}.\n
+            Add a remote that uses one of the currently supported providers.",
+            SupportedProviders::get_providers()
+        )),
+    }
+}
+
 pub trait GitProvider {
-	async fn create_pull_request(&self, trunk: String) -> eyre::Result<()>;
+    async fn create_pull_request(
+        &self,
+        owner: &String,
+        repo: &String,
+        trunk: &String,
+    ) -> eyre::Result<()>;
+}
+
+pub fn provider_factory(provider: &SupportedProviders) -> Result<Box<impl GitProvider>> {
+    match provider {
+        SupportedProviders::GitHub => Ok(Box::new(github::GitHub::new()?)),
+    }
 }


### PR DESCRIPTION
Implement an enum for supported git providers to make it more straight forward to add others in the future
Implement the function provider_factory() which returns a specific struct (that implements the GitProvider trait) based on the argument string
