### PR TITLE
Make create_pull_request get current branch and a title as args

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,18 +1,23 @@
-use eyre::{Ok, Result};
+use color_eyre::Section;
+use eyre::{Ok, OptionExt, Result};
 
-use crate::{
-    git_client,
-    git_provider::{provider_factory, GitProvider},
-    project::settings::get_project_settings,
-};
+use crate::{git_client, git_provider::provider_factory, project::settings::get_project_settings};
 
 pub async fn submit() -> Result<()> {
-    let (provider, owner, repo) = git_client::get_git_client()?.get_repository_info()?;
-    let provider_obj = provider_factory(&provider)?;
+    let git_client = git_client::get_git_client()?;
+
+    let branch = git_client
+        .get_current_branch()
+        .ok_or_eyre("Failed to get the current branch")
+        .suggestion("Check whether you are checked out onto a branch")?;
+    let title = branch.clone();
     let trunk = get_project_settings()?.get_trunk()?;
 
+    let (provider, owner, repo) = git_client.get_repository_info()?;
+    let provider_obj = provider_factory(&provider)?;
+
     provider_obj
-        .create_pull_request(&owner, &repo, &trunk)
+        .create_pull_request(&title, &branch, &owner, &repo, &trunk)
         .await?;
 
     Ok(())

--- a/src/git_provider/github.rs
+++ b/src/git_provider/github.rs
@@ -14,6 +14,8 @@ impl GitHub {
 impl GitProvider for GitHub {
     async fn create_pull_request(
         &self,
+        title: &String,
+        branch: &String,
         owner: &String,
         repo: &String,
         trunk: &String,
@@ -27,14 +29,12 @@ impl GitProvider for GitHub {
 
         let _pr = octocrab
             .pulls(owner, repo)
-            .create("title", "head", trunk)
+            .create(title, branch, trunk)
             .body("hello world!")
             .send()
             .await
             .context("Failed to create pull request")
             .suggestion("Please check your GitHub credentials")?;
-
-        println!("Creating pull request");
 
         Ok(())
     }

--- a/src/git_provider/mod.rs
+++ b/src/git_provider/mod.rs
@@ -45,6 +45,8 @@ pub fn get_provider_enum(provider: &str) -> Result<SupportedProviders> {
 pub trait GitProvider {
     async fn create_pull_request(
         &self,
+        title: &String,
+        branch: &String,
         owner: &String,
         repo: &String,
         trunk: &String,


### PR DESCRIPTION
For now, the title of the pr is the same as the branches name
