### PR TITLE
Remove the global variable for Git Client

### DIFF
--- a/src/git_client/mod.rs
+++ b/src/git_client/mod.rs
@@ -1,10 +1,7 @@
 use crate::git_provider::SupportedProviders;
-use crate::IssueError;
 
 use self::git_cli::GitCli;
 use eyre::Result;
-use once_cell::sync::Lazy;
-use std::sync::{Mutex, MutexGuard};
 
 pub mod git_cli;
 
@@ -138,13 +135,6 @@ pub trait GitClient: Send + Sync {
     fn update_ref(&self, refname: &str, oid: &str) -> Result<()>;
 }
 
-static GIT_CLIENT: Lazy<Mutex<Box<dyn GitClient>>> =
-    Lazy::new(|| Mutex::new(Box::new(GitCli::new().unwrap())));
-
-pub fn get_git_client() -> Result<MutexGuard<'static, Box<dyn GitClient>>> {
-    let guard = GIT_CLIENT
-        .lock()
-        .to_issue_error("Failed to get git client lock")?;
-
-    Ok(guard)
+pub fn get_git_client() -> Result<Box<dyn GitClient>> {
+    return Ok(Box::new(GitCli::new()?));
 }


### PR DESCRIPTION
It's easier to return a new owned value every time, because the GitCli structure
does not retain any state.