### PR TITLE
Add option to change pr title and body; add success message after sending pr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "thiserror",
@@ -461,6 +462,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1439,6 +1449,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
 color-eyre = {version = "0.6.3", default-features = false}
-dialoguer = "0.11.0"
+dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = "5.0.1"
 eyre = "0.6.12"
 octocrab = "0.38.0"

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -1,8 +1,9 @@
 use color_eyre::Section;
-use eyre::{Ok, OptionExt, Result};
+use eyre::{Context, Ok, OptionExt, Result};
 
 use crate::{
-    git_client, git_provider::provider_factory, git_provider::GitProvider,
+    git_client,
+    git_provider::{ask_for_pr_title, provider_factory, ask_for_pr_body, GitProvider},
     project::settings::get_project_settings,
 };
 
@@ -13,14 +14,22 @@ pub async fn submit() -> Result<()> {
         .get_current_branch()
         .ok_or_eyre("Failed to get the current branch")
         .suggestion("Check whether you are checked out onto a branch")?;
-    let title = branch.clone();
     let trunk = get_project_settings()?.get_trunk()?;
+
+    let commit_title = git_client
+        .get_current_commit_title()
+        .context("Failed to get the current commit title")
+        .suggestion("Check if you have any commits in your branch")?;
+    let title = ask_for_pr_title(&commit_title)?;
+
+    let commit_body = git_client.get_current_commit_body()?;
+    let body = ask_for_pr_body(&commit_body)?;    
 
     let (provider, owner, repo) = git_client.get_repository_info()?;
     let provider_obj = provider_factory(&provider)?;
 
     provider_obj
-        .create_pull_request(&owner, &repo, &title, &branch, &trunk)
+        .create_pull_request(&owner, &repo, &title, &branch, &trunk, &body)
         .await?;
 
     Ok(())

--- a/src/git_client/git_cli.rs
+++ b/src/git_client/git_cli.rs
@@ -156,6 +156,26 @@ impl GitClient for GitCli {
         Ok(title)
     }
 
+    fn get_current_commit_body(&self) -> Result<String> {
+        // Executes the `git log -1 --pretty=%b` command to get the body of the current commit.
+        let output = Command::new("git")
+            .args(["log", "-1", "--pretty=%b"])
+            .output()
+            .context("Failed to get the current commit body")?;
+
+        // Filters out the "Signed-off-by:" line from the commit body.
+        let body = String::from_utf8(output.stdout)
+            .context("Failed to parse the current commit body")?
+            .lines()
+            .filter(|line| !line.contains("Signed-off-by:"))
+            .collect::<Vec<&str>>()
+            .join("\n")
+            .trim()
+            .to_string();
+
+        Ok(body)
+    }
+
     fn delete_branch(&self, branch: &str) -> Result<()> {
         // Executes the `git branch -D <branch>` command to delete the specified branch.
         let output = Command::new("git")

--- a/src/git_client/mod.rs
+++ b/src/git_client/mod.rs
@@ -82,6 +82,13 @@ pub trait GitClient: Send + Sync {
     /// The title of the current commit as a `Result<String>`.
     fn get_current_commit_title(&self) -> Result<String>;
 
+    /// Retrieves the body of the current commit.
+    /// 
+    /// # Returns
+    /// 
+    /// The body of the current commit as a `Result<String>`.
+    fn get_current_commit_body(&self) -> Result<String>;
+
     /// Deletes the specified branch.
     ///
     /// # Arguments

--- a/src/git_provider/github.rs
+++ b/src/git_provider/github.rs
@@ -56,9 +56,9 @@ https://github.com/settings/tokens/new?description=Gi&scopes=repo,read:org,read:
                 .suggestion("Check if you have write permissions to the .config/gi directory")?;
 
             /* TODO: Implement setting file permissions on Windows
-             At the time of writing this code, fs::Permissions::from_mode only
-             works on Unix systems. In the future, we'll find a way to perform
-             the same operation on Windows. */
+            At the time of writing this code, fs::Permissions::from_mode only
+            works on Unix systems. In the future, we'll find a way to perform
+            the same operation on Windows. */
 
             let permissions = fs::Permissions::from_mode(0o600);
             fs::set_permissions(&token_file, permissions)
@@ -88,6 +88,7 @@ https://github.com/settings/tokens/new?description=Gi&scopes=repo,read:org,read:
         title: &String,
         branch: &String,
         trunk: &String,
+        body: &String,
     ) -> Result<()> {
         let token = self.get_token()?;
 
@@ -97,14 +98,20 @@ https://github.com/settings/tokens/new?description=Gi&scopes=repo,read:org,read:
             .context("Failed to create octocrab instance")
             .suggestion("Please check your GitHub personal access token")?;
 
-        let _pr = octocrab
+        let pr = octocrab
             .pulls(owner, repo)
             .create(title, branch, trunk)
-            .body("Automatically created by Gi")
+            .body(body)
             .send()
             .await
             .context("Failed to create pull request")
             .suggestion("Please check your GitHub personal access token")?;
+
+        let pr_url = pr.html_url.ok_or_eyre("Failed to get pull request URL")?;
+        println!(
+            "\nPull request created successfully! You can check it out at:\n{}",
+            pr_url
+        );
 
         Ok(())
     }


### PR DESCRIPTION
I also added a function that returns the current commit body (without any signatures) in GitClient.
Furthermore, I changed the parameters of the create_pull_request function, because I believe it's more logical for it not to have to handle getting all the elements required for creating a PR, 'submit' should do that
When selecting the description for the PR, the prompt defaults to using the commit body
