### PR TITLE
Define pr title and body inside create_pr func

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -3,7 +3,7 @@ use eyre::{Ok, OptionExt, Result};
 
 use crate::{
     git_client,
-    git_provider::{ask_for_pr_body, ask_for_pr_title, provider_factory, GitProvider},
+    git_provider::{provider_factory, GitProvider},
     project::settings::get_project_settings,
 };
 
@@ -16,18 +16,12 @@ pub async fn submit() -> Result<()> {
         .suggestion("Check whether you are checked out onto a branch")?;
     let trunk = get_project_settings()?.get_trunk()?;
 
-    let commit_title = git_client.get_current_commit_title()?;
-    let title = ask_for_pr_title(&commit_title)?;
-
-    let commit_body = git_client.get_current_commit_body()?;
-    let body = ask_for_pr_body(&commit_body)?;
-
     let (provider, owner, repo) = git_client.get_repository_info()?;
     let provider_obj = provider_factory(&provider)?;
 
     git_client.push_branch(&branch)?;
     provider_obj
-        .create_pull_request(&owner, &repo, &title, &branch, &trunk, &body)
+        .create_pull_request(&owner, &repo, &branch, &trunk)
         .await?;
 
     Ok(())

--- a/src/git_provider/mod.rs
+++ b/src/git_provider/mod.rs
@@ -114,16 +114,16 @@ pub fn ask_for_pr_body(commit_body: &String) -> Result<String> {
 
 /// Trait representing a Git provider.
 pub trait GitProvider {
-    /// Sets the token for authentication.
+    /// Sets the authentication token.
     ///
     /// # Arguments
     ///
-    /// * `path` - The path to the token file.
+    /// * `path` - The path to the file where the token should be stored.
     ///
     /// # Returns
     ///
     /// Returns a `Result` containing the token as a `String` if successful, or an error if the token cannot be set.
-    fn set_token(&self, path: &PathBuf) -> Result<String>;
+    fn ask_for_token(&self, path: &PathBuf) -> Result<String>;
 
     /// Retrieves the authentication token.
     ///
@@ -133,27 +133,23 @@ pub trait GitProvider {
     fn get_token(&self) -> Result<String>;
 
     /// Creates a pull request.
-    ///
+    /// 
     /// # Arguments
-    ///
+    /// 
     /// * `owner` - The owner of the repository.
     /// * `repo` - The name of the repository.
-    /// * `title` - The title of the pull request.
     /// * `branch` - The name of the branch to create the pull request from.
-    /// * `trunk` - The name of the branch to merge the pull request into.
-    /// * `body` - The body of the pull request.
-    ///
+    /// * `trunk` - The name of the trunk branch to create the pull request against.
+    /// 
     /// # Returns
-    ///
-    /// Returns a `Result` indicating whether the pull request was successfully created or an error occurred.
+    /// 
+    /// Returns a `Result` containing `()` if successful, or an error if the pull request cannot be created.
     async fn create_pull_request(
         &self,
         owner: &String,
         repo: &String,
-        title: &String,
         branch: &String,
         trunk: &String,
-        body: &String,
     ) -> eyre::Result<()>;
 }
 


### PR DESCRIPTION
I have two arguments for doing this:
- if the access token isn't set, the user should be asked to generate one before being asked for pr title and body
- to place the prompts asking for pr title and body after the creation of the octocrab instance, so in case it fails the user doesn't have to set the pr title and body
